### PR TITLE
jdarith.c: Require cinfo->Se == DCTSIZE2 - 1

This fixes an oversight from the integration of the arithmetic entropy
codec from libjpeg (66f97e6820e2cc9ef7429ea36285c80ffda87c8f).  I chose
to integrate the latest implementation available at the time, which was
from jpeg-8b.  However, I naively replaced cinfo->lim_Se with
DCTSIZE2 - 1, not realizing that-- because of SmartScale-- jpeg-8b
contains additional code
(https://github.com/libjpeg-turbo/libjpeg-turbo/blob/jpeg-8b/jdinput.c#L249-L334)
that guards against illegal values of cinfo->Se >= DCTSIZE2.  Thus,
libjpeg-turbo's implementation of arithmetic decoding has never guarded
against such illegal values.  This commit restores the relevant check
from the original jpeg-6b arithmetic entropy codec patch ("jpeg-ari",
1e247ac854f8e33682bcfea475f6bccc42377208).

Fixes #564

### DIFF
--- a/jdarith.c
+++ b/jdarith.c
@@ -679,8 +679,8 @@ start_pass (j_decompress_ptr cinfo)
     /* Check that the scan parameters Ss, Se, Ah/Al are OK for sequential JPEG.
      * This ought to be an error condition, but we make it a warning.
      */
-    if (cinfo->Ss != 0 || cinfo->Ah != 0 || cinfo->Al != 0 ||
-	(cinfo->Se < DCTSIZE2 && cinfo->Se != DCTSIZE2 - 1))
+    if (cinfo->Ss != 0 || cinfo->Se != DCTSIZE2-1 ||
+	cinfo->Ah != 0 || cinfo->Al != 0)
       WARNMS(cinfo, JWRN_NOT_SEQUENTIAL);
     /* Select MCU decoding routine */
     entropy->pub.decode_mcu = decode_mcu;


### PR DESCRIPTION
**Complete description of the bug fix or feature that this pull request implements**


**Checklist before submitting the pull request, to maximize the chances that the pull request will be accepted**

- [ ] Read CONTRIBUTING.md, a link to which appears under "Helpful resources" below.  That document discusses general guidelines for contributing to libjpeg-turbo, as well as the types of contributions that will not be accepted or are unlikely to be accepted.
- [ ] Search the existing issues and pull requests (both open and closed) to ensure that a similar request has not already been submitted and rejected.
- [ ] Discuss the proposed bug fix or feature in a GitHub issue, through direct e-mail with the project maintainer, or on the libjpeg-turbo-devel mailing list.
